### PR TITLE
[fixed] Crash due to continuous pushing

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -2,6 +2,7 @@ let table = document.getElementById("table100")
 let pinNotFound = document.getElementById("pin")
 let pin
 var available_centers = [];
+let loadingBoolean = true
 
 var today = new Date();
 var dd = String(today.getDate()).padStart(2, '0');
@@ -10,16 +11,18 @@ var yyyy = today.getFullYear();
 today = dd + '-' + mm + '-' + yyyy;
 
 $(document).ready(function(){
+    if (loadingBoolean){
     getAvailability();
     setInterval(() => {
         getAvailability();
-    }, 5000);
+    }, 5000);}
 });
 function getAvailability() {
     $.ajax({
         url: "https://cdn-api.co-vin.in/api/v2/appointment/sessions/public/calendarByDistrict?district_id=446&date="+today,
         type: "GET",
         success: function(results) {
+            available_centers = []
             // console.log(results.centers);
             if (results.centers && results.centers.length) {
                 var is_available = false;
@@ -92,6 +95,7 @@ function prepareHtml(data) {
 }
 
 function filterData(){
+    let loadingBoolean = false
     data = available_centers
     let filteredArray = []
     input = document.getElementById("myInput");
@@ -103,6 +107,7 @@ function filterData(){
             filteredArray.push(data[i])
         }
     }}
+    let loadingBoolean = true
     prepareHtml(filteredArray);
     }
 


### PR DESCRIPTION
Fixed the bug caused by keeping available centre outside and not making it as [] at every call.
The available centres used to append all calls and thus caused the browser to slow down or crash.
Now it clears the available centres every new call, but doesn't do so while filtering.